### PR TITLE
Correction for option "default_entity_id".

### DIFF
--- a/custom_components/modbus_manager/binary_sensor.py
+++ b/custom_components/modbus_manager/binary_sensor.py
@@ -186,9 +186,9 @@ class ModbusCoordinatorBinarySensor(BinarySensorEntity):
             if isinstance(default_entity_id, str):
                 default_entity_id = default_entity_id.lower()
             if "." in default_entity_id:
-                self._attr_entity_id = default_entity_id
+                self.entity_id = default_entity_id
             else:
-                self._attr_entity_id = f"binary_sensor.{default_entity_id}"
+                self.entity_id = f"binary_sensor.{default_entity_id}"
 
         # Binary sensors are typically diagnostic (status indicators)
         entity_category_str = register_config.get("entity_category")

--- a/custom_components/modbus_manager/button.py
+++ b/custom_components/modbus_manager/button.py
@@ -88,9 +88,9 @@ class ModbusCoordinatorButton(ButtonEntity):
             if isinstance(default_entity_id, str):
                 default_entity_id = default_entity_id.lower()
             if "." in default_entity_id:
-                self._attr_entity_id = default_entity_id
+                self.entity_id = default_entity_id
             else:
-                self._attr_entity_id = f"button.{default_entity_id}"
+                self.entity_id = f"button.{default_entity_id}"
 
         # Buttons should appear under device controls
         self._attr_entity_category = EntityCategory.CONFIG

--- a/custom_components/modbus_manager/calculated.py
+++ b/custom_components/modbus_manager/calculated.py
@@ -75,9 +75,9 @@ class ModbusCalculatedSensor(SensorEntity):
             if isinstance(default_entity_id, str):
                 default_entity_id = default_entity_id.lower()
             if "." in default_entity_id:
-                self._attr_entity_id = default_entity_id
+                self.entity_id = default_entity_id
             else:
-                self._attr_entity_id = f"sensor.{default_entity_id}"
+                self.entity_id = f"sensor.{default_entity_id}"
         # Set has_entity_name=False so friendly_name uses _attr_name directly (prefix entityname format)
         self._attr_has_entity_name = False
 
@@ -492,9 +492,9 @@ class ModbusCalculatedBinarySensor(BinarySensorEntity):
             if isinstance(default_entity_id, str):
                 default_entity_id = default_entity_id.lower()
             if "." in default_entity_id:
-                self._attr_entity_id = default_entity_id
+                self.entity_id = default_entity_id
             else:
-                self._attr_entity_id = f"binary_sensor.{default_entity_id}"
+                self.entity_id = f"binary_sensor.{default_entity_id}"
         # Set has_entity_name=False so friendly_name uses _attr_name directly (prefix entityname format)
         self._attr_has_entity_name = False
 

--- a/custom_components/modbus_manager/number.py
+++ b/custom_components/modbus_manager/number.py
@@ -74,9 +74,9 @@ class ModbusCoordinatorNumber(CoordinatorEntity, NumberEntity):
             if isinstance(default_entity_id, str):
                 default_entity_id = default_entity_id.lower()
             if "." in default_entity_id:
-                self._attr_entity_id = default_entity_id
+                self.entity_id = default_entity_id
             else:
-                self._attr_entity_id = f"number.{default_entity_id}"
+                self.entity_id = f"number.{default_entity_id}"
         self._attr_native_unit_of_measurement = register_config.get(
             "unit_of_measurement", ""
         )

--- a/custom_components/modbus_manager/select.py
+++ b/custom_components/modbus_manager/select.py
@@ -47,9 +47,9 @@ class ModbusCoordinatorSelect(CoordinatorEntity, SelectEntity):
             if isinstance(default_entity_id, str):
                 default_entity_id = default_entity_id.lower()
             if "." in default_entity_id:
-                self._attr_entity_id = default_entity_id
+                self.entity_id = default_entity_id
             else:
-                self._attr_entity_id = f"select.{default_entity_id}"
+                self.entity_id = f"select.{default_entity_id}"
         self._attr_icon = register_config.get("icon")
 
         # Selects should appear under device controls

--- a/custom_components/modbus_manager/sensor.py
+++ b/custom_components/modbus_manager/sensor.py
@@ -75,9 +75,9 @@ class ModbusCoordinatorSensor(CoordinatorEntity, SensorEntity):
             if isinstance(default_entity_id, str):
                 default_entity_id = default_entity_id.lower()
             if "." in default_entity_id:
-                self._attr_entity_id = default_entity_id
+                self.entity_id = default_entity_id
             else:
-                self._attr_entity_id = f"sensor.{default_entity_id}"
+                self.entity_id = f"sensor.{default_entity_id}"
         self._attr_native_unit_of_measurement = register_config.get(
             "unit_of_measurement", ""
         )

--- a/custom_components/modbus_manager/switch.py
+++ b/custom_components/modbus_manager/switch.py
@@ -91,9 +91,9 @@ class ModbusCoordinatorSwitch(SwitchEntity):
             if isinstance(default_entity_id, str):
                 default_entity_id = default_entity_id.lower()
             if "." in default_entity_id:
-                self._attr_entity_id = default_entity_id
+                self.entity_id = default_entity_id
             else:
-                self._attr_entity_id = f"switch.{default_entity_id}"
+                self.entity_id = f"switch.{default_entity_id}"
 
         # Switches should appear under device controls
         self._attr_entity_category = EntityCategory.CONFIG

--- a/custom_components/modbus_manager/text.py
+++ b/custom_components/modbus_manager/text.py
@@ -90,9 +90,9 @@ class ModbusCoordinatorText(TextEntity):
             if isinstance(default_entity_id, str):
                 default_entity_id = default_entity_id.lower()
             if "." in default_entity_id:
-                self._attr_entity_id = default_entity_id
+                self.entity_id = default_entity_id
             else:
-                self._attr_entity_id = f"text.{default_entity_id}"
+                self.entity_id = f"text.{default_entity_id}"
 
         # Text entities should appear under device controls
         self._attr_entity_category = EntityCategory.CONFIG


### PR DESCRIPTION
This option is official in the HA documentation, but requires direct access to the entity_id. See the component "templates" as an example.