### PR TITLE
Add entity_category for any entities

### DIFF
--- a/custom_components/modbus_manager/button.py
+++ b/custom_components/modbus_manager/button.py
@@ -105,8 +105,20 @@ class ModbusCoordinatorButton(ButtonEntity):
         # Write each update to the state machine, even if the data is the same.
         self._attr_force_update = register_config.get("force_update", False)
 
-        # Buttons should appear under device controls
-        self._attr_entity_category = EntityCategory.CONFIG
+        # Set entity category:
+        # - None (default): Primary sensors that represent main data points.
+        # - diagnostic: Used for read-only information about the device’s health or status.
+        # - config: Used for entities that change how a device behaves.
+        # An entity with a category will:
+        # - Not be exposed to cloud, Alexa, or Google Assistant components.
+        # - Not be included in indirect service calls to devices or areas.
+        entity_category_str = register_config.get("entity_category")
+        if entity_category_str == "diagnostic":
+            self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        elif entity_category_str == "config":
+            self._attr_entity_category = EntityCategory.CONFIG
+        else:
+            self._attr_entity_category = None
 
         # Get device info from register_config (provided by coordinator)
         device_info = register_config.get("device_info")

--- a/custom_components/modbus_manager/calculated.py
+++ b/custom_components/modbus_manager/calculated.py
@@ -122,14 +122,19 @@ class ModbusCalculatedSensor(SensorEntity):
         self._attr_state_class = config.get("state_class")
         self._attr_entity_registry_enabled_default = True
 
-        # Set entity category - calculated sensors are typically primary (None) or diagnostic
+        # Set entity category:
+        # - None (default): Primary sensors that represent main data points.
+        # - diagnostic: Used for read-only information about the device’s health or status.
+        # - config: Used for entities that change how a device behaves.
+        # An entity with a category will:
+        # - Not be exposed to cloud, Alexa, or Google Assistant components.
+        # - Not be included in indirect service calls to devices or areas.
         entity_category_str = config.get("entity_category")
         if entity_category_str == "diagnostic":
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
         elif entity_category_str == "config":
             self._attr_entity_category = EntityCategory.CONFIG
         else:
-            # Default: None for primary calculated sensors (main data points)
             self._attr_entity_category = None
 
         # Icon support

--- a/custom_components/modbus_manager/number.py
+++ b/custom_components/modbus_manager/number.py
@@ -86,9 +86,20 @@ class ModbusCoordinatorNumber(CoordinatorEntity, NumberEntity):
         self._attr_device_class = register_config.get("device_class")
         self._attr_icon = register_config.get("icon")
 
-        # Numbers allow changing device configuration - ALWAYS CONFIG category
-        # Controls (switches, numbers, selects, buttons, text) should NEVER be DIAGNOSTIC
-        self._attr_entity_category = EntityCategory.CONFIG
+        # Set entity category:
+        # - None (default): Primary sensors that represent main data points.
+        # - diagnostic: Used for read-only information about the device’s health or status.
+        # - config: Used for entities that change how a device behaves.
+        # An entity with a category will:
+        # - Not be exposed to cloud, Alexa, or Google Assistant components.
+        # - Not be included in indirect service calls to devices or areas.
+        entity_category_str = register_config.get("entity_category")
+        if entity_category_str == "diagnostic":
+            self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        elif entity_category_str == "config":
+            self._attr_entity_category = EntityCategory.CONFIG
+        else:
+            self._attr_entity_category = None
 
         # Number-specific properties
         raw_min_value = register_config.get("min_value", 0)

--- a/custom_components/modbus_manager/select.py
+++ b/custom_components/modbus_manager/select.py
@@ -55,8 +55,20 @@ class ModbusCoordinatorSelect(CoordinatorEntity, SelectEntity):
         self._attr_force_update = register_config.get("force_update", False)
         self._attr_icon = register_config.get("icon")
 
-        # Selects should appear under device controls
-        # self._attr_entity_category = EntityCategory.CONFIG
+        # Set entity category:
+        # - None (default): Primary sensors that represent main data points.
+        # - diagnostic: Used for read-only information about the device’s health or status.
+        # - config: Used for entities that change how a device behaves.
+        # An entity with a category will:
+        # - Not be exposed to cloud, Alexa, or Google Assistant components.
+        # - Not be included in indirect service calls to devices or areas.
+        entity_category_str = register_config.get("entity_category")
+        if entity_category_str == "diagnostic":
+            self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        elif entity_category_str == "config":
+            self._attr_entity_category = EntityCategory.CONFIG
+        else:
+            self._attr_entity_category = None
 
         # Select-specific properties
         self._attr_options = list(register_config.get("options", {}).values())

--- a/custom_components/modbus_manager/sensor.py
+++ b/custom_components/modbus_manager/sensor.py
@@ -39,7 +39,6 @@ async def _handle_group_assignments(
                     registry.async_update_entity(
                         entity_id,
                         entity_category=None,  # Keep existing category
-                        group=sensor._group,
                     )
 
     except Exception as e:
@@ -87,15 +86,19 @@ class ModbusCoordinatorSensor(CoordinatorEntity, SensorEntity):
         self._attr_device_class = register_config.get("device_class")
         self._attr_state_class = register_config.get("state_class")
 
-        # Set entity category - diagnostic for register info, None for primary sensors
-        # Diagnostic sensors expose configuration/diagnostics but don't allow changing them
+        # Set entity category:
+        # - None (default): Primary sensors that represent main data points.
+        # - diagnostic: Used for read-only information about the device’s health or status.
+        # - config: Used for entities that change how a device behaves.
+        # An entity with a category will:
+        # - Not be exposed to cloud, Alexa, or Google Assistant components.
+        # - Not be included in indirect service calls to devices or areas.
         entity_category_str = register_config.get("entity_category")
         if entity_category_str == "diagnostic":
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
         elif entity_category_str == "config":
             self._attr_entity_category = EntityCategory.CONFIG
         else:
-            # Default: None for primary sensors (main data points)
             self._attr_entity_category = None
 
         # Store scaling and precision for value processing

--- a/custom_components/modbus_manager/switch.py
+++ b/custom_components/modbus_manager/switch.py
@@ -110,8 +110,20 @@ class ModbusCoordinatorSwitch(SwitchEntity):
         # Write each update to the state machine, even if the data is the same.
         self._attr_force_update = register_config.get("force_update", False)
 
-        # Switches should appear under device controls
-        self._attr_entity_category = EntityCategory.CONFIG
+        # Set entity category:
+        # - None (default): Primary sensors that represent main data points.
+        # - diagnostic: Used for read-only information about the device’s health or status.
+        # - config: Used for entities that change how a device behaves.
+        # An entity with a category will:
+        # - Not be exposed to cloud, Alexa, or Google Assistant components.
+        # - Not be included in indirect service calls to devices or areas.
+        entity_category_str = register_config.get("entity_category")
+        if entity_category_str == "diagnostic":
+            self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        elif entity_category_str == "config":
+            self._attr_entity_category = EntityCategory.CONFIG
+        else:
+            self._attr_entity_category = None
 
         # Get device info from register_config (provided by coordinator)
         device_info = register_config.get("device_info")

--- a/custom_components/modbus_manager/text.py
+++ b/custom_components/modbus_manager/text.py
@@ -107,8 +107,20 @@ class ModbusCoordinatorText(TextEntity):
         # Write each update to the state machine, even if the data is the same.
         self._attr_force_update = register_config.get("force_update", False)
 
-        # Text entities should appear under device controls
-        self._attr_entity_category = EntityCategory.CONFIG
+        # Set entity category:
+        # - None (default): Primary sensors that represent main data points.
+        # - diagnostic: Used for read-only information about the device’s health or status.
+        # - config: Used for entities that change how a device behaves.
+        # An entity with a category will:
+        # - Not be exposed to cloud, Alexa, or Google Assistant components.
+        # - Not be included in indirect service calls to devices or areas.
+        entity_category_str = register_config.get("entity_category")
+        if entity_category_str == "diagnostic":
+            self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        elif entity_category_str == "config":
+            self._attr_entity_category = EntityCategory.CONFIG
+        else:
+            self._attr_entity_category = None
 
         # Get device info from register_config (provided by coordinator)
         device_info = register_config.get("device_info")


### PR DESCRIPTION
Any entities can be used for various purposes.
Should not severely restrict users.
https://developers.home-assistant.io/docs/core/entity/

From core cons.py description.
# An entity with a category will:
        # - Not be exposed to cloud, Alexa, or Google Assistant components.
        # - Not be included in indirect service calls to devices or areas.