### PR TITLE
fix: flag sensor state stays numeric (HA 255-char limit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 🐛 Fixed
+
+- **Flag sensors (255-character state limit)**: Sensors with template `flags` now always publish the numeric bitmask as state; human-readable flag labels are in the `formatted_value` attribute (truncated when needed). Fixes Home Assistant core errors for registers such as BMS alarm/protection/fault raw ([#58](https://github.com/TCzerny/ha-modbus-manager/issues/58)).
+
 ## [1.0.9] - 2026-04-24
 
 ### 🐛 Fixed

--- a/custom_components/modbus_manager/const.py
+++ b/custom_components/modbus_manager/const.py
@@ -57,6 +57,9 @@ DEFAULT_PRECISION = 2  # Standard-Präzision
 DEFAULT_MIN_VALUE = 0.0  # Standard-Minimum
 DEFAULT_MAX_VALUE = 100.0  # Standard-Maximum
 
+# Home Assistant rejects entity states longer than this (see homeassistant.core)
+MAX_ENTITY_STATE_LENGTH: Final = 255
+
 DEFAULT_SLAVE = 1
 DEFAULT_PORT = 502
 

--- a/custom_components/modbus_manager/coordinator.py
+++ b/custom_components/modbus_manager/coordinator.py
@@ -1929,19 +1929,22 @@ class ModbusCoordinator(DataUpdateCoordinator):
                         or register.get("flags")
                     )
                     numeric_value = None
-                    if has_mapping and isinstance(processed_value, (int, float)):
-                        # Calculate numeric value before mapping (with scale/offset/precision but without mapping)
-                        # Use process_register_value but stop before mapping
-                        from .value_processor import process_register_value
-
-                        # Create a copy of register config without mapping
-                        numeric_config = register.copy()
-                        numeric_config.pop("map", None)
-                        numeric_config.pop("flags", None)
-                        numeric_config.pop("options", None)
-                        numeric_value = process_register_value(
-                            processed_value, numeric_config, apply_precision=True
+                    if has_mapping:
+                        from .value_processor import (
+                            coerce_numeric_register_value,
+                            process_register_value,
                         )
+
+                        raw_numeric = coerce_numeric_register_value(processed_value)
+                        if raw_numeric is not None:
+                            # Numeric value before map/flags/options (scale/offset/precision only)
+                            numeric_config = register.copy()
+                            numeric_config.pop("map", None)
+                            numeric_config.pop("flags", None)
+                            numeric_config.pop("options", None)
+                            numeric_value = process_register_value(
+                                raw_numeric, numeric_config, apply_precision=True
+                            )
 
                     # Store processed data
                     register_data = {

--- a/custom_components/modbus_manager/sensor.py
+++ b/custom_components/modbus_manager/sensor.py
@@ -21,6 +21,7 @@ from .device_utils import (
 )
 from .logger import ModbusManagerLogger
 from .template_loader import load_templates
+from .value_processor import resolve_flags_sensor_values
 
 _LOGGER = ModbusManagerLogger(__name__)
 
@@ -125,7 +126,8 @@ class ModbusCoordinatorSensor(CoordinatorEntity, SensorEntity):
             or register_config.get("flags")
         )
         # Distinguish between flags (bitwise operations) and map/options (string mapping)
-        self._has_flags = bool(register_config.get("flags"))
+        self._flags = register_config.get("flags") or {}
+        self._has_flags = bool(self._flags)
         self._has_map_or_options = bool(
             register_config.get("map") or register_config.get("options")
         )
@@ -177,26 +179,21 @@ class ModbusCoordinatorSensor(CoordinatorEntity, SensorEntity):
                 processed_value = register_data.get("processed_value")
                 numeric_value = register_data.get("numeric_value")
 
-                if processed_value is not None:
-                    # Distinguish between flags (bitwise operations) and map/options (string mapping)
-                    # - Flags (e.g., running_state): Use numeric value for template compatibility
-                    # - Map/Options (e.g., cable_status): Use mapped string value for display
-                    if self._has_flags and numeric_value is not None:
-                        # For flags: Use numeric value as state (for bitwise operations in templates)
-                        # Store formatted string (from flags) in attributes for display
-                        self._attr_native_value = numeric_value
-                        formatted_string = (
-                            str(processed_value)
-                            if isinstance(processed_value, str)
-                            else processed_value
-                        )
-                        self._attr_extra_state_attributes = {
-                            **self._attr_extra_state_attributes,
-                            "raw_value": raw_value if raw_value is not None else "N/A",
-                            "processed_value": processed_value,
-                            "formatted_value": formatted_string,
-                        }
-                    elif self._has_map_or_options:
+                if self._has_flags:
+                    # Numeric state (bitmask) — never the joined flag labels (HA 255-char limit)
+                    flag_state, formatted_string = resolve_flags_sensor_values(
+                        register_data, self._flags
+                    )
+                    self._attr_native_value = flag_state
+                    self._attr_extra_state_attributes = {
+                        **self._attr_extra_state_attributes,
+                        "raw_value": raw_value if raw_value is not None else "N/A",
+                        "processed_value": processed_value,
+                        "formatted_value": formatted_string,
+                    }
+                elif processed_value is not None:
+                    # Map/Options (e.g., cable_status): Use mapped string value for display
+                    if self._has_map_or_options:
                         # For map/options: Use mapped string value as state
                         # This allows templates to check for string values like "no cable"
                         self._attr_native_value = (

--- a/custom_components/modbus_manager/value_processor.py
+++ b/custom_components/modbus_manager/value_processor.py
@@ -4,8 +4,9 @@ This module provides centralized value processing functions that can be used
 by both legacy sensors and coordinator-based entities.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
+from .const import MAX_ENTITY_STATE_LENGTH
 from .logger import ModbusManagerLogger
 
 _LOGGER = ModbusManagerLogger(__name__)
@@ -102,6 +103,74 @@ def apply_bit_operations(value: Any, config: Dict[str, Any]) -> Optional[int]:
         return value
 
 
+def coerce_numeric_register_value(value: Any) -> int | float | None:
+    """Coerce a raw register value to a number for flag/bitwise processing."""
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.isdigit() or (stripped.startswith("-") and stripped[1:].isdigit()):
+            return int(stripped)
+    return None
+
+
+def format_active_flags(value: int | float, flags: Dict[Any, Any]) -> str:
+    """Return comma-separated active flag labels, or 'None' when no bits are set."""
+    int_value = int(value)
+    active_flags: list[str] = []
+    for bit_pos, flag_name in flags.items():
+        try:
+            bit = int(bit_pos)
+            if 0 <= bit <= 31 and (int_value >> bit) & 1:
+                active_flags.append(str(flag_name))
+        except (ValueError, TypeError):
+            _LOGGER.warning("Invalid flag bit position: %s", bit_pos)
+    if active_flags:
+        return ", ".join(active_flags)
+    return "None"
+
+
+def truncate_entity_state_string(
+    text: str, max_length: int = MAX_ENTITY_STATE_LENGTH
+) -> str:
+    """Truncate text so it fits Home Assistant's entity state length limit."""
+    if len(text) <= max_length:
+        return text
+    if max_length <= 3:
+        return text[:max_length]
+    return text[: max_length - 3] + "..."
+
+
+def resolve_flags_sensor_values(
+    register_data: Dict[str, Any], flags: Dict[Any, Any]
+) -> tuple[Union[int, float, None], str]:
+    """Resolve numeric entity state and display string for flag-based sensors.
+
+    Entity state must stay numeric (bitmask) to avoid HA's 255-character state limit.
+    The human-readable flag list is returned for use in attributes only.
+    """
+    raw_value = register_data.get("raw_value")
+    numeric_value = register_data.get("numeric_value")
+    processed_value = register_data.get("processed_value")
+
+    state = numeric_value
+    if state is None:
+        state = coerce_numeric_register_value(raw_value)
+    if state is None:
+        state = coerce_numeric_register_value(processed_value)
+
+    if state is not None:
+        formatted = format_active_flags(state, flags)
+    elif isinstance(processed_value, str):
+        formatted = processed_value
+    else:
+        formatted = "None"
+
+    return state, truncate_entity_state_string(formatted)
+
+
 def apply_value_mapping(value: Any, config: Dict[str, Any]) -> Any:
     """Apply value mapping (map, flags, options) to a value.
 
@@ -143,20 +212,10 @@ def apply_value_mapping(value: Any, config: Dict[str, Any]) -> Any:
 
         # 2. Apply flags (bit flags to list)
         flags = config.get("flags")
-        if flags and isinstance(value, (int, float)):
-            int_value = int(value)
-            active_flags = []
-            for bit_pos, flag_name in flags.items():
-                try:
-                    bit = int(bit_pos)
-                    if 0 <= bit <= 31:
-                        if (int_value >> bit) & 1:
-                            active_flags.append(flag_name)
-                except (ValueError, TypeError):
-                    _LOGGER.warning("Invalid flag bit position: %s", bit_pos)
-            if active_flags:
-                return ", ".join(active_flags)
-            return "None"
+        if flags:
+            numeric = coerce_numeric_register_value(value)
+            if numeric is not None:
+                return format_active_flags(numeric, flags)
 
         # 3. Apply options (similar to map but for specific use case)
         options = config.get("options")


### PR DESCRIPTION
## Summary

- Flag-based sensors (`flags` in device templates) now always publish the numeric bitmask as entity state instead of the comma-separated label list.
- Human-readable flag text moves to the `formatted_value` attribute (truncated when needed).
- Coordinator resolves `numeric_value` more reliably before mapping.

Fixes #58.

## Context

Home Assistant rejects sensor states longer than 255 characters. When many BMS flag bits are active at once, the joined label string exceeds that limit and HA logs an error (`falling back to unknown`). v1.0.9 already intended numeric state when `numeric_value` was present; this hardens the path when it was missing.

## Test plan

- [ ] Reload integration with Sungrow SHx + battery enabled
- [ ] Check `sensor.*_bms_alarm_raw`, `*_bms_protection_raw`, `*_bms_fault_1_raw`: state is numeric; `formatted_value` shows labels
- [ ] Confirm no `State ... is longer than 255` errors in the log when many/all bits are set
- [ ] Verify existing templates using `bitwise_and` on flag sensors still work


Made with [Cursor](https://cursor.com)