### PR TITLE
Update SH*RS series registers

### DIFF
--- a/custom_components/modbus_manager/device_templates/sungrow_shx_dynamic.yaml
+++ b/custom_components/modbus_manager/device_templates/sungrow_shx_dynamic.yaml
@@ -2930,6 +2930,8 @@ controls:
     mode: "box"  # Explicitly set to box for consistent UI display
     scan_interval: 30
     mm_group: "PV_control"
+    condition: "selected_model not in [SH3.0RS, SH3.6RS, SH4.0RS, SH5.0RS, SH6.0RS, SH8.0RS, SH10RS]"
+    # Confirmed non-functional at this address on SH10RS/SH6.0RS
 
   - type: "select"
     name: "Active Power Limitation"
@@ -2942,6 +2944,22 @@ controls:
       0x55: "Disabled"
       0xAA: "Enabled"
     mm_group: "PV_control"
+    condition: "selected_model not in [SH3.0RS, SH3.6RS, SH4.0RS, SH5.0RS, SH6.0RS, SH8.0RS, SH10RS]"
+    # Confirmed non-functional at this address on SH10RS/SH6.0RS
+
+  - type: "select"
+    name: "Active Power Limitation"
+    unique_id: "active_power_limitation"
+    address: 31203 # reg 31204
+    input_type: "holding"
+    data_type: "uint16"
+    scan_interval: 30
+    options:
+      0x55: "Disabled"
+      0xAA: "Enabled"
+    mm_group: "PV_control"
+    condition: "selected_model in [SH3.0RS, SH3.6RS, SH4.0RS, SH5.0RS, SH6.0RS, SH8.0RS, SH10RS]"
+    # Confirmed functional at this address on SH10RS
 
   - type: "number"
     name: "Active Power Limit Ratio"
@@ -2957,6 +2975,25 @@ controls:
     step: 1
     scan_interval: 30
     mm_group: "PV_control"
+    condition: "selected_model not in [SH3.0RS, SH3.6RS, SH4.0RS, SH5.0RS, SH6.0RS, SH8.0RS, SH10RS]"
+    # Confirmed non-functional at this address on SH10RS/SH6.0RS
+
+  - type: "number"
+    name: "Active Power Limit Ratio"
+    unique_id: "active_power_limit_ratio"
+    address: 31204 # reg 31205
+    input_type: "holding"
+    data_type: "uint16"
+    precision: 1
+    unit_of_measurement: "%"
+    scale: 0.1
+    min_value: 0
+    max_value: 1000
+    step: 1
+    scan_interval: 30
+    mm_group: "PV_control"
+    condition: "selected_model in [SH3.0RS, SH3.6RS, SH4.0RS, SH5.0RS, SH6.0RS, SH8.0RS, SH10RS]"
+    # Confirmed functional at this address on SH10RS/SH6.0RS
 
   - type: "number"
     name: "Reserved SoC for Backup"
@@ -3055,9 +3092,10 @@ controls:
     scale: 10
     scan_interval: 10
     mm_group: "PV_battery_control"
-    condition: "battery_enabled == true"
+    condition: "battery_enabled == true and selected_model not in [SH3.0RS, SH3.6RS, SH4.0RS, SH5.0RS, SH6.0RS, SH8.0RS, SH10RS]"
     # Placeholder will be replaced with 50% of model-specific max_charge_power
     # For SH10RT: 10600 * 0.5 = 5300 W
+    # Confirmed non-functional on SH6.0RS and SH10RS
 
   - type: "number"
     name: "Battery Discharging Start Power"
@@ -3075,9 +3113,10 @@ controls:
     scale: 10
     scan_interval: 10
     mm_group: "PV_battery_control"
-    condition: "battery_enabled == true"
+    condition: "battery_enabled == true and selected_model not in [SH3.0RS, SH3.6RS, SH4.0RS, SH5.0RS, SH6.0RS, SH8.0RS, SH10RS]"
     # Placeholder will be replaced with 50% of model-specific max_discharge_power
     # For SH10RT: 10600 * 0.5 = 5300 W
+    # Confirmed non-functional on SH6.0RS and SH10RS
 
   - type: "select"
     name: "Forced Startup Under Low SoC Standby"


### PR DESCRIPTION
## Summary

For SH*RS inverters:

* Remove the following sensors:

  * Battery Charging Start Power
  * Battery Discharging Start Power
  * Export Power Limit Ratio

* Update the registers used for:

  * Active Power Limitation
  * Active Power Limit Ratio

## Reason

The removed sensors  are not supported on SH*RS models. The registers used for Active Power Limitation and Active Power Limit Ratio differ from those used on other SH inverter variants.

## Testing

Tested on an SH10RS inverter.

The same behaviour has also been reported for the SH6.0RS:
https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant/pull/724#issuecomment-4735269755
