### PR TITLE
Update SH10RS power limits in sungrow_shx_dynamic.yaml

### DIFF
--- a/custom_components/modbus_manager/device_templates/sungrow_shx_dynamic.yaml
+++ b/custom_components/modbus_manager/device_templates/sungrow_shx_dynamic.yaml
@@ -60,8 +60,9 @@ dynamic_config:
     # Battery Power Limits (from datasheet V2): max_charge_power (W), max_discharge_power (W)
     # AC Output Power Limits (from datasheet V2): max_ac_output_power (W)
     # Both models: 10000W charge / 10000W discharge (50A max current)
+    # SH10RS actual max is 10600W. Out of the box the modbus registers read 10600W.
     "SH8.0RS": {phases: 1, mppt_count: 4, string_count: 1, type_code: "0xD1A", max_charge_power: 10000, max_discharge_power: 10000, max_ac_output_power: 8000}
-    "SH10RS": {phases: 1, mppt_count: 4, string_count: 1, type_code: "0xD1B", max_charge_power: 10000, max_discharge_power: 10000, max_ac_output_power: 10000}
+    "SH10RS": {phases: 1, mppt_count: 4, string_count: 1, type_code: "0xD1B", max_charge_power: 10600, max_discharge_power: 10600, max_ac_output_power: 10600}
 
     # SH5.0-10RT Series (Three Phase)
     # Battery Power Limits (from datasheet): max_charge_power (W), max_discharge_power (W)


### PR DESCRIPTION
SH10RS power limits updated from 10000W to 10600W. This is inline with the value the modbus registers read out of the box. Also testing writing to the register allows 1060 to be written  Trying to set 1061 (10610 W) using mbpoll. Errors out and reading back register it is still at the old value prior to attempting to set out of range 1061. 

mbpoll -a 1 -r 33048 -t 4 -p 502 -1 10.40.0.30 -v 1061 debug enabled
Set device=10.40.0.30
1 write data have been found
Set data=1061
Word[0]=0x425
mbpoll 1.0-0 - FieldTalk(tm) Modbus(R) Master Simulator Copyright © 2015-2019 Pascal JEAN, https://github.com/epsilonrt/mbpoll This program comes with ABSOLUTELY NO WARRANTY.
This is free software, and you are welcome to redistribute it under certain conditions; type 'mbpoll -w' for details.

Connecting to [10.40.0.30]:502
Set response timeout to 1 sec, 0 us
Protocol configuration: Modbus TCP
Slave configuration...: address = [1]
start reference = 33048, count = 1
Communication.........: 10.40.0.30, port 502, t/o 1.00 s, poll rate 1000 ms Data type.............: 16-bit register, output (holding) register table

[00][01][00][00][00][06][01][06][81][17][04][25]
Waiting for a confirmation...
<00><01><00><00><00><03><01><86><04>
ERROR Slave device or server failure
Write output (holding) register failed: Slave device or server failure