### PR TITLE
Add MPPT3 and MPPT4  to 30 day graphs

### DIFF
--- a/Dashboard-Examples/sungrow_pv_analysis_mushroom.yaml
+++ b/Dashboard-Examples/sungrow_pv_analysis_mushroom.yaml
@@ -591,6 +591,10 @@ views:
                 name: MPPT1 Voltage
               - entity: sensor.{PREFIX_INVERTER}_mppt2_voltage
                 name: MPPT2 Voltage
+              - entity: sensor.{PREFIX_INVERTER}_mppt3_voltage
+                name: MPPT3 Voltage
+              - entity: sensor.{PREFIX_INVERTER}_mppt4_voltage
+                name: MPPT4 Voltage
             days_to_show: 30
             chart_type: line
             stat_types:
@@ -605,6 +609,10 @@ views:
                 name: MPPT1 Current
               - entity: sensor.{PREFIX_INVERTER}_mppt2_current
                 name: MPPT2 Current
+              - entity: sensor.{PREFIX_INVERTER}_mppt3_current
+                name: MPPT3 Current
+              - entity: sensor.{PREFIX_INVERTER}_mppt4_current
+                name: MPPT4 Current
             days_to_show: 30
             chart_type: line
             stat_types:

--- a/Dashboard-Examples/sungrow_pv_analysis_standard.yaml
+++ b/Dashboard-Examples/sungrow_pv_analysis_standard.yaml
@@ -305,6 +305,10 @@ views:
                 name: MPPT1 Voltage
               - entity: sensor.{PREFIX_INVERTER}_mppt2_voltage
                 name: MPPT2 Voltage
+              - entity: sensor.{PREFIX_INVERTER}_mppt3_voltage
+                name: MPPT3 Voltage
+              - entity: sensor.{PREFIX_INVERTER}_mppt4_voltage
+                name: MPPT4 Voltage
             days_to_show: 30
             chart_type: line
             stat_types:

--- a/Dashboard-Examples/sungrow_pv_analysis_standard.yaml
+++ b/Dashboard-Examples/sungrow_pv_analysis_standard.yaml
@@ -319,6 +319,10 @@ views:
                 name: MPPT1 Current
               - entity: sensor.{PREFIX_INVERTER}_mppt2_current
                 name: MPPT2 Current
+              - entity: sensor.{PREFIX_INVERTER}_mppt3_current
+                name: MPPT3 Current
+              - entity: sensor.{PREFIX_INVERTER}_mppt4_current
+                name: MPPT4 Current
             days_to_show: 30
             chart_type: line
             stat_types:


### PR DESCRIPTION
Found MPPT3 and MPPT4 were missing from the 30day graphs in both
Dashboard-Examples/sungrow_pv_analysis_mushroom.yaml
Dashboard-Examples/sungrow_pv_analysis_standard.yaml