### PR TITLE
Exclude 13016 Forced Startup Under Low SoC for SH*RS inverters

### DIFF
--- a/custom_components/modbus_manager/device_templates/sungrow_shx_dynamic.yaml
+++ b/custom_components/modbus_manager/device_templates/sungrow_shx_dynamic.yaml
@@ -2671,7 +2671,9 @@ sensors:
     options:
       0x55: "Disabled"
       0xAA: "Enabled"
-    condition: "battery_enabled == true"
+    condition: "selected_model not in [SH3.0RS, SH3.6RS, SH4.0RS, SH5.0RS, SH6.0RS, SH8.0RS, SH10RS]"
+    # Confirmed non-functional at this address on SH10RS/SH6.0RS
+
 
  ################################################################
  # Wallbox Registers (read-only, only when wallbox is connected)
@@ -3129,7 +3131,9 @@ controls:
       0x55: "Disabled"
       0xAA: "Enabled"
     mm_group: "PV_control"
-    condition: "battery_enabled == true"
+    condition: "selected_model not in [SH3.0RS, SH3.6RS, SH4.0RS, SH5.0RS, SH6.0RS, SH8.0RS, SH10RS]"
+    # Confirmed non-functional at this address on SH10RS/SH6.0RS
+
 
   - type: "select"
     name: "PV Power Limitation"


### PR DESCRIPTION
Exclude 13016 Forced Startup Under Low SoC for SH*RS inverters
Forced Startup Under Low SoC 13016 returns NaN value on SH*RS inverters

2026-06-29 15:56:47.545 DEBUG (MainThread) [custom_components.modbus_manager.select] Select Forced Startup Under Low SoC Standby: Value 65535.0 not found in options - state unknown