### PR TITLE
 Remove duplicate map key  - sungrow_shx_dynamic.yaml

### DIFF
--- a/custom_components/modbus_manager/device_templates/sungrow_shx_dynamic.yaml
+++ b/custom_components/modbus_manager/device_templates/sungrow_shx_dynamic.yaml
@@ -264,7 +264,6 @@ sensors:
       3368: "MG6RL"
       3369: "MG8RL"
       3370: "MG10RL"
-    mm_group: "PV_device_info"
 
   - name: Protocol version raw
     unique_id: protocol_version_raw


### PR DESCRIPTION
Remove duplicate `mm_group: "PV_device_info` from `- name: Sungrow device type code`
Sungrow device type code had the same mm_group twice.
modified:   custom_components/modbus_manager/device_templates/sungrow_shx_dynamic.yaml